### PR TITLE
Fix: starter-workflows lies a bit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   pull_request:
-    branches: [ $default-branch ]
+    branches: [ main ]
   push:
-    branches: [ $default-branch ]
+    branches: [ main ]
 
 jobs:
   test:


### PR DESCRIPTION
Apparently default-branch interpolation happens at the template level, not workflow level.