### PR TITLE
Add pre-commit hooks, ruff lint, and lint rules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,14 @@ jobs:
         python-version: ${{ matrix.python-version }}
         uv-version: latest
 
+    - name: Lint with ruff
+      run: |
+        uv run --extra dev ruff check
+
     - name: Type check with pyright
       run: |
-        uv run --extra testing pyright
+        uv run --extra dev pyright
 
     - name: Test on python ${{ matrix.python-version }} and generate coverage
       run: |
-        uv run --extra testing pytest -ra --cov --cov-report=html --cov-report=term -- tests
+        uv run --extra dev pytest -ra --cov --cov-report=html --cov-report=term -- tests

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,20 @@
+repos:
+  - repo: local
+    hooks:
+      - id: ruff
+        name: Lint with ruff
+        entry: uv run --extra dev ruff check
+        language: system
+        types: [python]
+
+      - id: pyright
+        name: Type check with pyright
+        entry: uv run --extra dev pyright
+        language: system
+        types: [python]
+
+      - id: pytest
+        name: Run pytest with coverage
+        entry: uv run --extra dev pytest -- tests
+        language: system
+        pass_filenames: false

--- a/docs/index.md
+++ b/docs/index.md
@@ -90,12 +90,20 @@ As an explicit goal is to minimize dependency constraints, only the following de
 
 Please report any bugs, type-related issues/inconsistencies, and feel free to suggest new generic components! Any issues or PRs are welcome.
 
+=== "Environment"
+
+    Our development environment uses [uv](https://docs.astral.sh/uv/getting-started/installation/); install (and set up the [pre-commit](https://pre-commit.com/) hooks) with
+    ```sh
+    uv sync --extra dev
+    uv run pre-commit install
+    ```
+    You can test the hooks with `uv run pre-commit run`; these hooks (`ruff` + `pyright` + `pytest`) mirror the CI.
+
 === "Run Tests"
 
-    The test suite isn't fully automated yet; run tests with
+    Run tests with
     ```sh
-    uv run --extra testing coverage run -m pytest tests
-    uv run --extra testing coverage report
+    uv run --extra dev pytest -ra --cov --cov-report=html --cov-report=term -- tests
     ```
 
     !!! info

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,36 +42,57 @@ docs = [
     "mkdocstrings-python-xref == 1.16.3",
     "mkdocstrings-python == 1.16.6",
     "mkdocstrings == 0.29.*",
-    "ruff"
+    "ruff >= 0.10.0"
 ]
-testing = [
+dev = [
+    "pre-commit >= 4.0.0",
     "coverage",
     "pytest",
     "pytest-cov",
-    "pyright",
-    "beartype",
+    "beartype >= 0.20.0",
     "optree >= 0.13",
     "torch >= 2.2",
-    "pyright",
+    "pyright >= 1.0.0",
+    "ruff >= 0.10.0"
 ]
 torch = [
     "optree >= 0.13",
     "torch >= 2.2"
 ]
 
+[tool.ruff]
+line-length = 80
+indent-width = 4
+
+[tool.ruff.lint]
+select = [
+    "W", "N", "I", "D", "NPY"
+]
+ignore = [
+    "D102",  # Inheriting docstrings is allowed
+    "D107",  # Initializer goes in the class docstring
+    "D401",  # "Imperative mood" NLP doesn't always make sense
+    "D413",  # No blank lines after section is preferred by mkdocstrings
+
+    # Must pick one...
+    "D213",  # Pick 'multi-line-summary-first-line'.
+    "D203",  # Pick `no-blank-line-before-class`.
+]
+
+
 # Use pytorch-cpu when we install the `testing` extra, but pytorch-gpu when
 # we install the `torch` extra.
 [tool.uv]
 conflicts = [
     [
-        { extra = "testing" },
+        { extra = "dev" },
         { extra = "torch" },
     ],
 ]
 
 [tool.uv.sources]
 torch = [
-    { index = "pytorch-cpu", extra = "testing" },
+    { index = "pytorch-cpu", extra = "dev" },
 ]
 
 [[tool.uv.index]]

--- a/tests/test_torch.py
+++ b/tests/test_torch.py
@@ -57,8 +57,8 @@ def test_composition():
 def test_collate():
     """Test collate function."""
     data = {
-        "a": np.random.uniform(size=(3, 5)),
-        "b": np.random.uniform(size=(3, 4))
+        "a": np.random.default_rng().uniform(size=(3, 5)),
+        "b": np.random.default_rng().uniform(size=(3, 4))
     }
 
     collate1 = adl_torch.Collate(mode='stack')

--- a/uv.lock
+++ b/uv.lock
@@ -2,22 +2,22 @@ version = 1
 revision = 2
 requires-python = ">=3.10"
 resolution-markers = [
-    "python_full_version >= '3.12' and extra != 'extra-19-abstract-dataloader-testing' and extra == 'extra-19-abstract-dataloader-torch'",
-    "python_full_version < '3.12' and extra != 'extra-19-abstract-dataloader-testing' and extra == 'extra-19-abstract-dataloader-torch'",
-    "python_full_version >= '3.12' and sys_platform != 'darwin' and extra == 'extra-19-abstract-dataloader-testing' and extra != 'extra-19-abstract-dataloader-torch'",
-    "python_full_version < '3.12' and sys_platform != 'darwin' and extra == 'extra-19-abstract-dataloader-testing' and extra != 'extra-19-abstract-dataloader-torch'",
-    "python_full_version >= '3.12' and sys_platform == 'darwin' and extra == 'extra-19-abstract-dataloader-testing' and extra != 'extra-19-abstract-dataloader-torch'",
-    "python_full_version < '3.12' and sys_platform == 'darwin' and extra == 'extra-19-abstract-dataloader-testing' and extra != 'extra-19-abstract-dataloader-torch'",
-    "extra != 'extra-19-abstract-dataloader-testing' and extra != 'extra-19-abstract-dataloader-torch'",
+    "python_full_version >= '3.12' and extra != 'extra-19-abstract-dataloader-dev' and extra == 'extra-19-abstract-dataloader-torch'",
+    "python_full_version < '3.12' and extra != 'extra-19-abstract-dataloader-dev' and extra == 'extra-19-abstract-dataloader-torch'",
+    "python_full_version >= '3.12' and sys_platform != 'darwin' and extra == 'extra-19-abstract-dataloader-dev' and extra != 'extra-19-abstract-dataloader-torch'",
+    "python_full_version < '3.12' and sys_platform != 'darwin' and extra == 'extra-19-abstract-dataloader-dev' and extra != 'extra-19-abstract-dataloader-torch'",
+    "python_full_version >= '3.12' and sys_platform == 'darwin' and extra == 'extra-19-abstract-dataloader-dev' and extra != 'extra-19-abstract-dataloader-torch'",
+    "python_full_version < '3.12' and sys_platform == 'darwin' and extra == 'extra-19-abstract-dataloader-dev' and extra != 'extra-19-abstract-dataloader-torch'",
+    "extra != 'extra-19-abstract-dataloader-dev' and extra != 'extra-19-abstract-dataloader-torch'",
 ]
 conflicts = [[
-    { package = "abstract-dataloader", extra = "testing" },
+    { package = "abstract-dataloader", extra = "dev" },
     { package = "abstract-dataloader", extra = "torch" },
 ]]
 
 [[package]]
 name = "abstract-dataloader"
-version = "0.3.1"
+version = "0.3.2"
 source = { editable = "." }
 dependencies = [
     { name = "jaxtyping" },
@@ -26,6 +26,18 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+dev = [
+    { name = "beartype" },
+    { name = "coverage" },
+    { name = "optree" },
+    { name = "pre-commit" },
+    { name = "pyright" },
+    { name = "pytest" },
+    { name = "pytest-cov" },
+    { name = "ruff" },
+    { name = "torch", version = "2.7.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'darwin' and extra == 'extra-19-abstract-dataloader-dev') or (extra == 'extra-19-abstract-dataloader-dev' and extra == 'extra-19-abstract-dataloader-torch')" },
+    { name = "torch", version = "2.7.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform != 'darwin' and extra == 'extra-19-abstract-dataloader-dev') or (extra == 'extra-19-abstract-dataloader-dev' and extra == 'extra-19-abstract-dataloader-torch')" },
+]
 docs = [
     { name = "mkdocs" },
     { name = "mkdocs-material" },
@@ -34,16 +46,6 @@ docs = [
     { name = "mkdocstrings-python-xref" },
     { name = "ruff" },
 ]
-testing = [
-    { name = "beartype" },
-    { name = "coverage" },
-    { name = "optree" },
-    { name = "pyright" },
-    { name = "pytest" },
-    { name = "pytest-cov" },
-    { name = "torch", version = "2.7.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'darwin' and extra == 'extra-19-abstract-dataloader-testing') or (extra == 'extra-19-abstract-dataloader-testing' and extra == 'extra-19-abstract-dataloader-torch')" },
-    { name = "torch", version = "2.7.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform != 'darwin' and extra == 'extra-19-abstract-dataloader-testing') or (extra == 'extra-19-abstract-dataloader-testing' and extra == 'extra-19-abstract-dataloader-torch')" },
-]
 torch = [
     { name = "optree" },
     { name = "torch", version = "2.7.0", source = { registry = "https://pypi.org/simple" } },
@@ -51,8 +53,8 @@ torch = [
 
 [package.metadata]
 requires-dist = [
-    { name = "beartype", marker = "extra == 'testing'" },
-    { name = "coverage", marker = "extra == 'testing'" },
+    { name = "beartype", marker = "extra == 'dev'", specifier = ">=0.20.0" },
+    { name = "coverage", marker = "extra == 'dev'" },
     { name = "jaxtyping", specifier = ">=0.2.32" },
     { name = "mkdocs", marker = "extra == 'docs'", specifier = "==1.6.*" },
     { name = "mkdocs-material", marker = "extra == 'docs'", specifier = "==9.6.*" },
@@ -60,17 +62,19 @@ requires-dist = [
     { name = "mkdocstrings-python", marker = "extra == 'docs'", specifier = "==1.16.6" },
     { name = "mkdocstrings-python-xref", marker = "extra == 'docs'", specifier = "==1.16.3" },
     { name = "numpy", specifier = ">=1.14" },
-    { name = "optree", marker = "extra == 'testing'", specifier = ">=0.13" },
+    { name = "optree", marker = "extra == 'dev'", specifier = ">=0.13" },
     { name = "optree", marker = "extra == 'torch'", specifier = ">=0.13" },
-    { name = "pyright", marker = "extra == 'testing'" },
-    { name = "pytest", marker = "extra == 'testing'" },
-    { name = "pytest-cov", marker = "extra == 'testing'" },
-    { name = "ruff", marker = "extra == 'docs'" },
-    { name = "torch", marker = "extra == 'testing'", specifier = ">=2.2", index = "https://download.pytorch.org/whl/cpu", conflict = { package = "abstract-dataloader", extra = "testing" } },
+    { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.0.0" },
+    { name = "pyright", marker = "extra == 'dev'", specifier = ">=1.0.0" },
+    { name = "pytest", marker = "extra == 'dev'" },
+    { name = "pytest-cov", marker = "extra == 'dev'" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.10.0" },
+    { name = "ruff", marker = "extra == 'docs'", specifier = ">=0.10.0" },
+    { name = "torch", marker = "extra == 'dev'", specifier = ">=2.2", index = "https://download.pytorch.org/whl/cpu", conflict = { package = "abstract-dataloader", extra = "dev" } },
     { name = "torch", marker = "extra == 'torch'", specifier = ">=2.2" },
     { name = "typing-extensions", specifier = ">=3.12" },
 ]
-provides-extras = ["docs", "testing", "torch"]
+provides-extras = ["docs", "dev", "torch"]
 
 [[package]]
 name = "babel"
@@ -110,6 +114,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1c/ab/c9f1e32b7b1bf505bf26f0ef697775960db7932abeb7b516de930ba2705f/certifi-2025.1.31.tar.gz", hash = "sha256:3d5da6925056f6f18f119200434a4780a94263f10d1c21d032a6f6b2baa20651", size = 167577, upload_time = "2025-01-31T02:16:47.166Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/38/fc/bce832fd4fd99766c04d1ee0eead6b0ec6486fb100ae5e74c1d91292b982/certifi-2025.1.31-py3-none-any.whl", hash = "sha256:ca78db4565a652026a4db2bcdf68f2fb589ea80d0be70e03929ed730746b84fe", size = 166393, upload_time = "2025-01-31T02:16:45.015Z" },
+]
+
+[[package]]
+name = "cfgv"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/11/74/539e56497d9bd1d484fd863dd69cbbfa653cd2aa27abfe35653494d85e94/cfgv-3.4.0.tar.gz", hash = "sha256:e52591d4c5f5dead8e0f673fb16db7949d2cfb3f7da4582893288f0ded8fe560", size = 7114, upload_time = "2023-08-12T20:38:17.776Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c5/55/51844dd50c4fc7a33b653bfaba4c2456f06955289ca770a5dbd5fd267374/cfgv-3.4.0-py2.py3-none-any.whl", hash = "sha256:b7265b1f29fd3316bfcd2b330d63d024f2bfd8bcb8b0272f8e19a504856c48f9", size = 7249, upload_time = "2023-08-12T20:38:16.269Z" },
 ]
 
 [[package]]
@@ -178,7 +191,7 @@ name = "click"
 version = "8.1.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-19-abstract-dataloader-testing' and extra == 'extra-19-abstract-dataloader-torch')" },
+    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-19-abstract-dataloader-dev' and extra == 'extra-19-abstract-dataloader-torch')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593, upload_time = "2024-12-21T18:38:44.339Z" }
 wheels = [
@@ -260,6 +273,15 @@ toml = [
 ]
 
 [[package]]
+name = "distlib"
+version = "0.3.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0d/dd/1bec4c5ddb504ca60fc29472f3d27e8d4da1257a854e1d96742f15c1d02d/distlib-0.3.9.tar.gz", hash = "sha256:a60f20dea646b8a33f3e7772f74dc0b2d0772d2837ee1342a00645c81edf9403", size = 613923, upload_time = "2024-10-09T18:35:47.551Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/91/a1/cf2472db20f7ce4a6be1253a81cfdf85ad9c7885ffbed7047fb72c24cf87/distlib-0.3.9-py2.py3-none-any.whl", hash = "sha256:47f8c22fd27c27e25a65601af709b38e4f0a45ea4fc2e710f65755fa8caaaf87", size = 468973, upload_time = "2024-10-09T18:35:44.272Z" },
+]
+
+[[package]]
 name = "exceptiongroup"
 version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
@@ -308,6 +330,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/59/08/7df7e90e34d08ad890bd71d7ba19451052f88dc3d2c483d228d1331a4736/griffe-1.7.2.tar.gz", hash = "sha256:98d396d803fab3b680c2608f300872fd57019ed82f0672f5b5323a9ad18c540c", size = 394919, upload_time = "2025-04-01T14:38:44.887Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b1/5e/38b408f41064c9fcdbb0ea27c1bd13a1c8657c4846e04dab9f5ea770602c/griffe-1.7.2-py3-none-any.whl", hash = "sha256:1ed9c2e338a75741fc82083fe5a1bc89cb6142efe126194cc313e34ee6af5423", size = 129187, upload_time = "2025-04-01T14:38:43.227Z" },
+]
+
+[[package]]
+name = "identify"
+version = "2.6.12"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/88/d193a27416618628a5eea64e3223acd800b40749a96ffb322a9b55a49ed1/identify-2.6.12.tar.gz", hash = "sha256:d8de45749f1efb108badef65ee8386f0f7bb19a7f26185f74de6367bffbaf0e6", size = 99254, upload_time = "2025-05-23T20:37:53.3Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/cd/18f8da995b658420625f7ef13f037be53ae04ec5ad33f9b718240dcfd48c/identify-2.6.12-py2.py3-none-any.whl", hash = "sha256:ad9672d5a72e0d2ff7c5c8809b62dfa60458626352fb0eb7b55e69bdc45334a2", size = 99145, upload_time = "2025-05-23T20:37:51.495Z" },
 ]
 
 [[package]]
@@ -434,7 +465,7 @@ version = "1.6.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
-    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-19-abstract-dataloader-testing' and extra == 'extra-19-abstract-dataloader-torch')" },
+    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-19-abstract-dataloader-dev' and extra == 'extra-19-abstract-dataloader-torch')" },
     { name = "ghp-import" },
     { name = "jinja2" },
     { name = "markdown" },
@@ -536,7 +567,7 @@ dependencies = [
     { name = "griffe" },
     { name = "mkdocs-autorefs" },
     { name = "mkdocstrings" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11' or (extra == 'extra-19-abstract-dataloader-testing' and extra == 'extra-19-abstract-dataloader-torch')" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11' or (extra == 'extra-19-abstract-dataloader-dev' and extra == 'extra-19-abstract-dataloader-torch')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/8e/e7/0691e34e807a8f5c28f0988fcfeeb584f0b569ce433bf341944f14bdb3ff/mkdocstrings_python-1.16.6.tar.gz", hash = "sha256:cefe0f0e17ab4a4611f01b0a2af75e4298664e0ff54feb83c91a485bfed82dc9", size = 201565, upload_time = "2025-03-18T15:34:24.371Z" }
 wheels = [
@@ -926,6 +957,22 @@ wheels = [
 ]
 
 [[package]]
+name = "pre-commit"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cfgv" },
+    { name = "identify" },
+    { name = "nodeenv" },
+    { name = "pyyaml" },
+    { name = "virtualenv" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/08/39/679ca9b26c7bb2999ff122d50faa301e49af82ca9c066ec061cfbc0c6784/pre_commit-4.2.0.tar.gz", hash = "sha256:601283b9757afd87d40c4c4a9b2b5de9637a8ea02eaff7adc2d0fb4e04841146", size = 193424, upload_time = "2025-03-18T21:35:20.987Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/74/a88bf1b1efeae488a0c0b7bdf71429c313722d1fc0f377537fbe554e6180/pre_commit-4.2.0-py2.py3-none-any.whl", hash = "sha256:a009ca7205f1eb497d10b845e52c838a98b6cdd2102a6c8e4540e94ee75c58bd", size = 220707, upload_time = "2025-03-18T21:35:19.343Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.19.1"
 source = { registry = "https://pypi.org/simple" }
@@ -982,7 +1029,7 @@ name = "pytest-cov"
 version = "6.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "coverage", extra = ["toml"], marker = "extra == 'extra-19-abstract-dataloader-testing'" },
+    { name = "coverage", extra = ["toml"], marker = "extra == 'extra-19-abstract-dataloader-dev'" },
     { name = "pluggy" },
     { name = "pytest" },
 ]
@@ -1314,6 +1361,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/8a/78/16493d9c386d8e60e442a35feac5e00f0913c0f4b7c217c11e8ec2ff53e0/urllib3-2.4.0.tar.gz", hash = "sha256:414bc6535b787febd7567804cc015fee39daab8ad86268f1310a9250697de466", size = 390672, upload_time = "2025-04-10T15:23:39.232Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6b/11/cc635220681e93a0183390e26485430ca2c7b5f9d33b15c74c2861cb8091/urllib3-2.4.0-py3-none-any.whl", hash = "sha256:4e16665048960a0900c702d4a66415956a584919c03361cac9f1df5c5dd7e813", size = 128680, upload_time = "2025-04-10T15:23:37.377Z" },
+]
+
+[[package]]
+name = "virtualenv"
+version = "20.31.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "distlib" },
+    { name = "filelock" },
+    { name = "platformdirs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/56/2c/444f465fb2c65f40c3a104fd0c495184c4f2336d65baf398e3c75d72ea94/virtualenv-20.31.2.tar.gz", hash = "sha256:e10c0a9d02835e592521be48b332b6caee6887f332c111aa79a09b9e79efc2af", size = 6076316, upload_time = "2025-05-08T17:58:23.811Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f3/40/b1c265d4b2b62b58576588510fc4d1fe60a86319c8de99fd8e9fec617d2c/virtualenv-20.31.2-py3-none-any.whl", hash = "sha256:36efd0d9650ee985f0cad72065001e66d49a6f24eb44d98980f630686243cf11", size = 6057982, upload_time = "2025-05-08T17:58:21.15Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Add ruff linter, and rule configuration for ruff in `pyproject.toml`
- Set up pre-commit hooks to mirror the CI
- Fix tests to use `np.random.default_rng().*` instead of `np.random.*`
- Rename the `testing` extra to `dev` to better reflect its use case (as the development environment)