### PR TITLE
Allow more manual control on windowing

### DIFF
--- a/src/abstract_dataloader/generic/sync.py
+++ b/src/abstract_dataloader/generic/sync.py
@@ -113,7 +113,7 @@ class Nearest(spec.Synchronization):
         tol: synchronization time tolerance, in seconds. Setting `tol = np.inf`
             works to disable this check altogether.
         margin: time margin (in seconds; `float`) or index margin
-            (in samples; `int`) to apply to the start end end time relative to
+            (in samples; `int`) to apply to the start and end time relative to
             the reference sensor, excluding samples within this margin.
     """
 

--- a/src/abstract_dataloader/generic/sync.py
+++ b/src/abstract_dataloader/generic/sync.py
@@ -44,10 +44,17 @@ class Next(spec.Synchronization):
 
     Args:
         reference: reference sensor to synchronize to.
+        margin: time margin (in seconds; `float`) or index margin
+            (in samples; `int`) to apply to the start and end, excluding
+            samples within this margin.
     """
 
-    def __init__(self, reference: str) -> None:
+    def __init__(
+        self, reference: str,
+        margin: tuple[int | float, int | float] = (0, 0)
+    ) -> None:
         self.reference = reference
+        self.margin = margin
 
     def __call__(
         self, timestamps: dict[str, Float64[np.ndarray, "_N"]]
@@ -70,8 +77,19 @@ class Next(spec.Synchronization):
         start_time = max(t[0] for t in timestamps.values())
         end_time = min(t[-1] for t in timestamps.values())
 
+        if isinstance(self.margin[0], float):
+            start_time += self.margin[0]
+        if isinstance(self.margin[1], float):
+            end_time -= self.margin[1]
+
         start_idx = np.searchsorted(ref_time_all, start_time)
         end_idx = np.searchsorted(ref_time_all, end_time)
+
+        if isinstance(self.margin[0], int):
+            start_idx += self.margin[0]
+        if isinstance(self.margin[1], int):
+            end_idx -= self.margin[1]
+
         ref_time = ref_time_all[start_idx:end_idx]
         return {
             k: np.searchsorted(v, ref_time).astype(np.uint32)
@@ -94,15 +112,22 @@ class Nearest(spec.Synchronization):
         reference: reference sensor to synchronize to.
         tol: synchronization time tolerance, in seconds. Setting `tol = np.inf`
             works to disable this check altogether.
+        margin: time margin (in seconds; `float`) or index margin
+            (in samples; `int`) to apply to the start end end time relative to
+            the reference sensor, excluding samples within this margin.
     """
 
-    def __init__(self, reference: str, tol: float = 0.1) -> None:
+    def __init__(
+        self, reference: str, tol: float = 0.1,
+        margin: tuple[int | float, int | float] = (0, 0)
+    ) -> None:
         if tol < 0:
             raise ValueError(
                 f"Synchronization tolerance must be positive: {tol} < 0")
 
         self.tol = tol
         self.reference = reference
+        self.margin = margin
 
     def __call__(
         self, timestamps: dict[str, Float64[np.ndarray, "_N"]]
@@ -122,11 +147,23 @@ class Nearest(spec.Synchronization):
                 f"Reference sensor {self.reference} was not provided in "
                 f"timestamps, with keys: {list(timestamps.keys())}")
 
+        if isinstance(self.margin[0], float):
+            t_ref = t_ref[np.argmax(t_ref > t_ref[0] + self.margin[0]):]
+        elif isinstance(self.margin[0], int) and self.margin[0] > 0:
+            t_ref = t_ref[self.margin[0]:]
+
+        if isinstance(self.margin[1], float):
+            t_ref = t_ref[
+                :-np.argmax((t_ref < t_ref[-1] - self.margin[1])[::-1])]
+        elif isinstance(self.margin[1], int) and self.margin[1] > 0:
+            t_ref = t_ref[:-self.margin[1]]
+
         indices = {
             k: np.searchsorted(
                 (t_sensor[:-1] + t_sensor[1:]) / 2, t_ref
             ).astype(np.uint32)
             for k, t_sensor in timestamps.items()}
+
         valid = np.all(np.array([
            np.abs(timestamps[k][i_nearest] - t_ref) < self.tol
         for k, i_nearest in indices.items()]), axis=0)

--- a/tests/test_composition.py
+++ b/tests/test_composition.py
@@ -43,6 +43,27 @@ def test_window(parallel):
     assert np.all(windowed.metadata.timestamps == np.array([1, 2, 3]))
 
 
+@pytest.mark.parametrize("parallel", [None, 1, 2])
+def test_window_uncropped(parallel) -> None:
+    """Test uncropped windowing."""
+    meta = _ConcreteMetadata(5)
+
+    partialed = generic.Window.from_partial_sensor(
+        lambda path: _ConcreteSensor(meta),
+        past=1, future=1, crop=False, parallel=parallel)
+    windowed = partialed("ignored")
+
+    assert windowed[1] == [0, 1, 2]
+    assert windowed[2] == [1, 2, 3]
+    assert windowed[3] == [2, 3, 4]
+    assert np.all(windowed.metadata.timestamps == np.array([0, 1, 2, 3, 4]))
+
+    with pytest.raises(IndexError):
+        _ = windowed[0]
+    with pytest.raises(IndexError):
+        _ = windowed[4]
+
+
 def test_transform():
     """Test sequence transforms."""
     pipeline = abstract.Pipeline(

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -48,6 +48,21 @@ def test_next(reference):
         assert np.all(np.diff(v) >= 0)
 
 
+def test_next_margin():
+    """generic.Next, with margin."""
+    ts = _make_timestamps()
+
+    sync = generic.Next("sensor1", margin=(1, 1))
+    indices = sync(ts)
+    assert indices["sensor1"].shape[0] == 1
+    assert np.allclose(indices["sensor1"], [2])
+
+    sync2 = generic.Next("sensor1", margin=(0.1, 1.1))
+    indices = sync2(ts)
+    assert indices["sensor1"].shape[0] == 1
+    assert np.allclose(indices["sensor1"], [2])
+
+
 def test_next_missing():
     """generic.Next, missing reference."""
     sync = generic.Next(reference="sensorX")
@@ -85,3 +100,18 @@ def test_nearest_bounds():
     """generic.Nearest; invalid tol."""
     with pytest.raises(ValueError):
         sync = generic.Nearest(reference="sensorX", tol=-0.5)  # noqa
+
+
+def test_nearest_margin():
+    """generic.Nearest, with margin."""
+    ts = _make_timestamps()
+
+    sync = generic.Nearest("sensor1", tol=1.0, margin=(1, 1))
+    indices = sync(ts)
+    assert indices["sensor1"].shape[0] == 4
+    assert np.allclose(indices["sensor1"], [1, 2, 3, 4])
+
+    sync2 = generic.Nearest("sensor1", tol=1.0, margin=(0.1, 1.1))
+    indices = sync2(ts)
+    assert indices["sensor1"].shape[0] == 3
+    assert np.allclose(indices["sensor1"], [1, 2, 3])


### PR DESCRIPTION
- Add a `crop` argument to `Window` which can be used to disable auto-cropping of timestamps (at the cost of raising IndexError if the caller attempts to access the first `past` or last `future` samples)
- Add a `margin` argument to the generic `Synchronization` policies which can be used to manually exclude samples from the start and end